### PR TITLE
Update `actions/cache` from `v3` to `v4`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         box:
-          - generic/freebsd12
           - generic/freebsd13
           - generic/freebsd14
       fail-fast: false
@@ -69,10 +68,8 @@ jobs:
     strategy:
       matrix:
         box:
-          - freebsd/FreeBSD-12.4-STABLE
           - freebsd/FreeBSD-13.3-STABLE
           - freebsd/FreeBSD-14.1-STABLE
-          - generic/freebsd12
           - generic/freebsd13
           - generic/freebsd14
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Provision VM
         uses: ./
@@ -65,20 +65,20 @@ jobs:
 
   FreeBSD-On-macOS:
     name: ${{ matrix.box }}
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         box:
           - freebsd/FreeBSD-12.4-STABLE
-          - freebsd/FreeBSD-13.2-STABLE
-          - freebsd/FreeBSD-14.0-STABLE
+          - freebsd/FreeBSD-13.3-STABLE
+          - freebsd/FreeBSD-14.1-STABLE
           - generic/freebsd12
           - generic/freebsd13
           - generic/freebsd14
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Provision VM
         uses: ./

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # FreeBSD Vagrant Action
 
-**The value for [runs-on](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on) must either be set to `macos-latest` or `ubuntu-latest` in order to use this action.**
+**The value for [runs-on](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on) must either be set to `macos-13` or `ubuntu-latest` in order to use this action.**
 
 This action allows the running of command-line programs via the `bash` shell of FreeBSD VMs provisioned with Vagrant using the [run](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun) keyword. This also works with composite actions which exclusively use the `run` keyword (and/or call other composite actions which also do so.)
 
 #### *This action is currently only tested with these boxes (but will probably also work with others):*
-  * `freebsd/FreeBSD-12.4-STABLE` (`macos-latest` only)
-  * `freebsd/FreeBSD-13.2-STABLE` (`macos-latest` only)
-  * `freebsd/FreeBSD-14.0-STABLE` (`macos-latest` only)
+  * `freebsd/FreeBSD-12.4-STABLE` (`macos-13` only)
+  * `freebsd/FreeBSD-13.3-STABLE` (`macos-13` only)
+  * `freebsd/FreeBSD-14.1-STABLE` (`macos-13` only)
   * `generic/freebsd12`
   * `generic/freebsd13`
   * `generic/freebsd14`
@@ -19,7 +19,7 @@ This action allows the running of command-line programs via the `bash` shell of 
     - name: Provision VM
       uses: hummeltech/freebsd-vagrant-action@v1.4
       with:
-        box: freebsd/FreeBSD-12.4-RELEASE
+        box: freebsd/FreeBSD-12.4-STABLE
         cpus: 2
         memory: 2048
     ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 This action allows the running of command-line programs via the `bash` shell of FreeBSD VMs provisioned with Vagrant using the [run](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun) keyword. This also works with composite actions which exclusively use the `run` keyword (and/or call other composite actions which also do so.)
 
 #### *This action is currently only tested with these boxes (but will probably also work with others):*
-  * `freebsd/FreeBSD-12.4-STABLE` (`macos-13` only)
   * `freebsd/FreeBSD-13.3-STABLE` (`macos-13` only)
   * `freebsd/FreeBSD-14.1-STABLE` (`macos-13` only)
-  * `generic/freebsd12`
   * `generic/freebsd13`
   * `generic/freebsd14`
 
@@ -19,7 +17,7 @@ This action allows the running of command-line programs via the `bash` shell of 
     - name: Provision VM
       uses: hummeltech/freebsd-vagrant-action@v1.4
       with:
-        box: freebsd/FreeBSD-12.4-STABLE
+        box: freebsd/FreeBSD-14.1-STABLE
         cpus: 2
         memory: 2048
     ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action allows the running of command-line programs via the `bash` shell of 
 1. Provision a `FreeBSD VM` using the specified `box` (with 2 CPUs & 2GB of RAM)
     ```yaml
     - name: Provision VM
-      uses: hummeltech/freebsd-vagrant-action@v1.4
+      uses: hummeltech/freebsd-vagrant-action@v1.5
       with:
         box: freebsd/FreeBSD-14.1-STABLE
         cpus: 2

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
 
     - name: Cache Vagrant Box
       if: inputs.save_box_to_cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.vagrant_box_descriptor }}
         key: ${{ inputs.box }}.box

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Allow running command-line programs via bash shell of FreeBSD VMs p
 
 inputs:
   box:
-    default: generic/freebsd13
+    default: generic/freebsd14
     description: Vagrant Box
     type: string
   cpus:
@@ -83,7 +83,7 @@ runs:
 
     - name: Install/Upgrade Vagrant (macOS)
       run: |
-        brew upgrade --force --quiet vagrant
+        brew install --cask --force --quiet vagrant virtualbox
       shell: bash
       if: runner.os == 'macOS'
 

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.vagrant_box_descriptor }}
-        key: ${{ inputs.box }}.box
+        key: ${{ inputs.box }}-${{ runner.os }}.box
 
     - name: Add Vagrant Box
       if: inputs.use_cached_box


### PR DESCRIPTION
_Also_:
- Update `freebsd/FreeBSD-*-STABLE` box versions
- Remove `FreeBSD 12`
- Update tests' `actions/checkout` from `v3` to `v4`
- Use `macos-13` rather than `macos-latest`
  - `macos-latest` now uses `ARM64` architecture

Closes #2 